### PR TITLE
Add address validation logic using postal codes

### DIFF
--- a/src/main/java/com/syedhamed/ecommerce/EcommerceApp.java
+++ b/src/main/java/com/syedhamed/ecommerce/EcommerceApp.java
@@ -1,15 +1,24 @@
 package com.syedhamed.ecommerce;
 
+import com.syedhamed.ecommerce.payload.external.PostalResponse;
+import com.syedhamed.ecommerce.service.contract.ExternalService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
 import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 @SpringBootApplication
 @EnableScheduling
+@RequiredArgsConstructor
 public class EcommerceApp {
 
-	public static void main(String[] args) {
-		SpringApplication.run(EcommerceApp.class, args);
-	}
-
+    public static void main(String[] args) {SpringApplication.run(EcommerceApp.class, args);}
 }

--- a/src/main/java/com/syedhamed/ecommerce/config/AppConfig.java
+++ b/src/main/java/com/syedhamed/ecommerce/config/AppConfig.java
@@ -5,6 +5,7 @@ import com.syedhamed.ecommerce.payload.APIResponse;
 import org.modelmapper.ModelMapper;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
 
 @Configuration
 public class AppConfig {
@@ -16,5 +17,7 @@ public class AppConfig {
     public APIResponse apiResponse(){
         return new APIResponse();
     }
+    @Bean
+    public RestTemplate restTemplate(){return new RestTemplate();}
 
 }

--- a/src/main/java/com/syedhamed/ecommerce/config/JacksonConfig.java
+++ b/src/main/java/com/syedhamed/ecommerce/config/JacksonConfig.java
@@ -1,0 +1,39 @@
+package com.syedhamed.ecommerce.config;
+
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
+
+@Configuration
+public class JacksonConfig {
+//    Lambda-style
+    @Bean
+    public Jackson2ObjectMapperBuilderCustomizer jacksonCustomizer() {
+        return builder -> {
+            builder.featuresToEnable(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES);
+            builder.failOnUnknownProperties(false);
+        };
+    }
+//    Old-Java style
+//    @Bean
+//    public Jackson2ObjectMapperBuilderCustomizer jacksonCustomizer() {
+//        return new Jackson2ObjectMapperBuilderCustomizer() {
+//            @Override
+//            public void customize(Jackson2ObjectMapperBuilder builder) {
+//                builder.featuresToEnable(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES);
+//                builder.failOnUnknownProperties(false);
+//            }
+//        };
+//    }
+// could also define own custom objectMapper but not needed
+//    @Bean
+//    public ObjectMapper objectMapper(){
+//        ObjectMapper mapper = new ObjectMapper();
+//        mapper.configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES, true);
+//        return mapper;
+//    }
+
+}

--- a/src/main/java/com/syedhamed/ecommerce/controllers/AddressController.java
+++ b/src/main/java/com/syedhamed/ecommerce/controllers/AddressController.java
@@ -3,7 +3,9 @@ package com.syedhamed.ecommerce.controllers;
 import com.syedhamed.ecommerce.enums.AddressType;
 import com.syedhamed.ecommerce.model.Address;
 import com.syedhamed.ecommerce.payload.APIResponse;
+import com.syedhamed.ecommerce.payload.external.ValidateAddressRequest;
 import com.syedhamed.ecommerce.service.contract.AddressService;
+import com.syedhamed.ecommerce.service.contract.ExternalService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -13,12 +15,14 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Map;
 
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/addresses")
 public class AddressController {
     private final AddressService addressService;
+    private final ExternalService externalService;
     private boolean isAdmin() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         return authentication.getAuthorities().stream()
@@ -111,6 +115,13 @@ public class AddressController {
         }
         List<Address> allAddresses = addressService.getAllAddresses();
         return ResponseEntity.ok(new APIResponse<>(allAddresses, "All addresses retrieved", true));
+    }
+
+    @PostMapping("/validate")
+    public ResponseEntity<APIResponse<Map<String, Object>>> validateAddress(@RequestBody ValidateAddressRequest validateAddressRequest){
+        APIResponse<Map<String, Object>> externalServiceResponse = externalService.validateAddress(validateAddressRequest.getPincode());
+        return new ResponseEntity<>(
+                externalServiceResponse,HttpStatus.OK);
     }
 
 

--- a/src/main/java/com/syedhamed/ecommerce/exceptions/APIException.java
+++ b/src/main/java/com/syedhamed/ecommerce/exceptions/APIException.java
@@ -1,7 +1,6 @@
 package com.syedhamed.ecommerce.exceptions;
 
 public class APIException extends RuntimeException {
-
     public APIException(String message) {
         super(message);
     }

--- a/src/main/java/com/syedhamed/ecommerce/payload/external/PostOffice.java
+++ b/src/main/java/com/syedhamed/ecommerce/payload/external/PostOffice.java
@@ -1,0 +1,41 @@
+package com.syedhamed.ecommerce.payload.external;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+@Data
+public class PostOffice {
+    @JsonProperty("Name")
+    private String name;
+
+    @JsonProperty("Description")
+    private String description;
+
+    @JsonProperty("BranchType")
+    private String branchType;
+
+    @JsonProperty("DeliveryStatus")
+    private String deliveryStatus;
+
+    @JsonProperty("Circle")
+    private String circle;
+
+    @JsonProperty("District")
+    private String district;
+
+    @JsonProperty("Division")
+    private String division;
+
+    @JsonProperty("Region")
+    private String region;
+
+    @JsonProperty("Block")
+    private String block;
+
+    @JsonProperty("State")
+    private String state;
+
+    @JsonProperty("Country")
+    private String country;
+
+    @JsonProperty("Pincode")
+    private String pincode;
+}

--- a/src/main/java/com/syedhamed/ecommerce/payload/external/PostalResponse.java
+++ b/src/main/java/com/syedhamed/ecommerce/payload/external/PostalResponse.java
@@ -1,0 +1,15 @@
+package com.syedhamed.ecommerce.payload.external;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import java.util.List;
+
+@Data
+public class PostalResponse {
+    @JsonProperty("Message")
+    private String message;
+    @JsonProperty("Status")
+    private String status;
+    @JsonProperty("PostOffice")
+    private List<PostOffice> postOffice;
+}

--- a/src/main/java/com/syedhamed/ecommerce/payload/external/ValidateAddressRequest.java
+++ b/src/main/java/com/syedhamed/ecommerce/payload/external/ValidateAddressRequest.java
@@ -1,0 +1,16 @@
+package com.syedhamed.ecommerce.payload.external;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ValidateAddressRequest {
+    @NotBlank(message = "Pincode must not be blank")
+    @Pattern(regexp = "\\d{6}", message = "Pincode must be a 6-digit number")
+    private String pincode;
+}

--- a/src/main/java/com/syedhamed/ecommerce/service/contract/AddressService.java
+++ b/src/main/java/com/syedhamed/ecommerce/service/contract/AddressService.java
@@ -4,6 +4,7 @@ import com.syedhamed.ecommerce.enums.AddressType;
 import com.syedhamed.ecommerce.model.Address;
 
 import java.util.List;
+import java.util.Map;
 
 public interface AddressService {
 
@@ -26,4 +27,5 @@ public interface AddressService {
     Address markAddressAsDefaultByAdmin(Long addressId);
 
     Address updateAddressByAdmin(Long addressId, Address updatedAddressRequest);
+
 }

--- a/src/main/java/com/syedhamed/ecommerce/service/contract/ExternalService.java
+++ b/src/main/java/com/syedhamed/ecommerce/service/contract/ExternalService.java
@@ -1,0 +1,9 @@
+package com.syedhamed.ecommerce.service.contract;
+
+import com.syedhamed.ecommerce.payload.APIResponse;
+
+import java.util.Map;
+
+public interface ExternalService {
+    APIResponse<Map<String, Object>> validateAddress(String pincode);
+}

--- a/src/main/java/com/syedhamed/ecommerce/service/implementation/AddressServiceImpl.java
+++ b/src/main/java/com/syedhamed/ecommerce/service/implementation/AddressServiceImpl.java
@@ -8,6 +8,7 @@ import com.syedhamed.ecommerce.model.User;
 import com.syedhamed.ecommerce.repository.AddressRepository;
 import com.syedhamed.ecommerce.repository.UserRepository;
 import com.syedhamed.ecommerce.service.contract.AddressService;
+import com.syedhamed.ecommerce.service.contract.ExternalService;
 import com.syedhamed.ecommerce.util.AuthUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,6 +18,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 @RequiredArgsConstructor
 @Slf4j
@@ -26,7 +28,7 @@ public class AddressServiceImpl implements AddressService {
     private final UserRepository userRepository;
     private final AddressRepository addressRepository;
     private final ModelMapper modelMapper;
-
+    private final ExternalService externalService;
     @Override
     public Address addAddress(Address addressRequest) {
         log.info("Is Default: [{}]", addressRequest.isDefaultAddress());
@@ -174,4 +176,5 @@ public class AddressServiceImpl implements AddressService {
 
         return addressRepository.save(existingAddress);
     }
+
 }

--- a/src/main/java/com/syedhamed/ecommerce/service/implementation/ExternalServiceImpl.java
+++ b/src/main/java/com/syedhamed/ecommerce/service/implementation/ExternalServiceImpl.java
@@ -1,0 +1,65 @@
+package com.syedhamed.ecommerce.service.implementation;
+
+import com.syedhamed.ecommerce.payload.APIResponse;
+import com.syedhamed.ecommerce.payload.external.PostOffice;
+import com.syedhamed.ecommerce.payload.external.PostalResponse;
+import com.syedhamed.ecommerce.service.contract.ExternalService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.net.URL;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class ExternalServiceImpl implements ExternalService {
+    private final RestTemplate restTemplate;
+
+    private String PINCODE_URI = "https://api.postalpincode.in/pincode/";
+
+    @Override
+    public APIResponse<Map<String, Object>> validateAddress(String pincode) {
+        String url = PINCODE_URI + pincode;
+        // Since externalResponse is an array, map to PostalResponse[]
+        ResponseEntity<PostalResponse[]> externalApiResponse =
+                restTemplate.exchange(url, HttpMethod.GET, null, PostalResponse[].class);
+        PostalResponse postalResponse = externalApiResponse.getBody()[0];
+        if (postalResponse != null) {
+            String status = postalResponse.getStatus();
+            if (!status.equalsIgnoreCase("Success")) {
+
+//                System.out.println("No records found with pincode" + pincode);
+                return new APIResponse<>("No records found with pincode " + pincode,
+                        false);
+
+            } else {
+//                System.out.println("Records found with pincode" + pincode);
+                String district = postalResponse.getPostOffice().get(0).getDistrict();
+                String block = postalResponse.getPostOffice().get(0).getBlock();
+                String state = postalResponse.getPostOffice().get(0).getState();
+                Map<String, Object> internalResponse = new HashMap<>();
+                internalResponse.put("district", district);
+                internalResponse.put("block", block);
+                internalResponse.put("state", state);
+                List<String> areaNames = postalResponse.getPostOffice()
+                        .stream().map(postOffice -> postOffice.getName()).toList();
+                internalResponse.put("areaNames", areaNames);
+                return new APIResponse<>(
+                        internalResponse,
+                        "Records found with pincode " + pincode,
+                        true
+                );
+            }
+        } else {
+            return new APIResponse<>(
+                    "Pincode Server Error",
+                    false
+            );
+        }
+    }
+}


### PR DESCRIPTION
### 📋 Pull Request Description

For now, the address validation feature is developed using a **separate endpoint**.  
It accepts a pincode through the `ValidateAddressRequest` DTO and validates it by calling the **India Postal Pincode API**.

In the next update, this logic will be **integrated inside the `addAddress` method** to validate addresses in real time during address creation.
