### PR TITLE
Fix multiple address-related issues including default address flag, LazyInitialization, and JWT bypass for registration

### DIFF
--- a/src/main/java/com/syedhamed/ecommerce/controllers/AddressController.java
+++ b/src/main/java/com/syedhamed/ecommerce/controllers/AddressController.java
@@ -99,7 +99,7 @@ public class AddressController {
         return ResponseEntity.ok(new APIResponse<>(defaultAddress, "Default address found", true));
     }
 
-    @GetMapping("/user/{userId}")
+    @GetMapping("/users/{userId}")
     public ResponseEntity<APIResponse<List<Address>>> getAllAddressesForUser(@PathVariable Long userId) {
         List<Address> addressesByUserId = addressService.getAddressesByUserId(userId);
         return ResponseEntity.ok(new APIResponse<>(addressesByUserId, "Addresses found", true));

--- a/src/main/java/com/syedhamed/ecommerce/exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/com/syedhamed/ecommerce/exceptions/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import org.springframework.data.mapping.PropertyReferenceException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -121,4 +122,12 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(apiResponse,HttpStatus.BAD_REQUEST);
     }
 
+
+    @ExceptionHandler(BadCredentialsException.class)
+    public ResponseEntity<APIResponse> badCredentialsException(BadCredentialsException e){
+        String message = e.getMessage();
+        apiResponse.setMessage(message);
+        apiResponse.setStatus(false);
+        return new ResponseEntity<>(apiResponse, HttpStatus.BAD_REQUEST);
+    }
 }

--- a/src/main/java/com/syedhamed/ecommerce/model/User.java
+++ b/src/main/java/com/syedhamed/ecommerce/model/User.java
@@ -31,7 +31,7 @@ public class User  {
 
 
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @Column(unique = true, nullable = false)
     private String email;    // unique

--- a/src/main/java/com/syedhamed/ecommerce/repository/AddressRepository.java
+++ b/src/main/java/com/syedhamed/ecommerce/repository/AddressRepository.java
@@ -1,7 +1,10 @@
 package com.syedhamed.ecommerce.repository;
 
 import com.syedhamed.ecommerce.model.Address;
+import com.syedhamed.ecommerce.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -9,5 +12,6 @@ import java.util.Optional;
 public interface AddressRepository extends JpaRepository<Address, Long> {
     List<Address> findByUser_Id(Long userId);
     Optional<Address> findByIdAndUser_Id(Long addressId, Long userId);
+
 
 }

--- a/src/main/java/com/syedhamed/ecommerce/repository/UserRepository.java
+++ b/src/main/java/com/syedhamed/ecommerce/repository/UserRepository.java
@@ -4,6 +4,8 @@ import com.syedhamed.ecommerce.model.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -21,4 +23,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> getUserByIdAndDeletedFalse(Long userId);
 
     List<User> findAllByDeactivatedTrue();
+
+    @Query("SELECT u FROM User u LEFT JOIN FETCH u.addresses WHERE u.id = :userId")
+    Optional<User> findByIdWithAddresses(@Param("userId") Long userId);
+
 }

--- a/src/main/java/com/syedhamed/ecommerce/security/JWTAuthFilter.java
+++ b/src/main/java/com/syedhamed/ecommerce/security/JWTAuthFilter.java
@@ -40,9 +40,9 @@ public class JWTAuthFilter extends OncePerRequestFilter {
 
         log.info("jwt filter started...");
         String path = request.getRequestURI();
-        log.info("Requested URI: " + path);
+        log.info("Requested URI: [{}}", path);
 
-        if (path.equals("/api/auth/login")) {
+        if (path.equals("/api/auth/login") || path.equals("/api/users/register")) {
             log.info("Login request won't be authenticated. Hence, passing the HttpServletRequest to subsequent filters");
             filterChain.doFilter(request, response);
             return;
@@ -98,19 +98,19 @@ public class JWTAuthFilter extends OncePerRequestFilter {
                 return;
 
             } catch (SignatureException ex) {
-                log.error("Invalid token signature", ex.getMessage());
+                log.error("Invalid token signature {}", ex.getMessage());
                 response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
                 response.getWriter().write("Invalid token signature");
                 return;
 
             } catch (JwtException ex) {
-                log.error("Malformed or invalid token", ex.getMessage());
+                log.error("Malformed or invalid token {}", ex.getMessage());
                 response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
                 response.getWriter().write("Invalid token");
                 return;
 
             } catch (UsernameNotFoundException ex){
-                log.error("User email in Token mismatch", ex.getMessage());
+                log.error("User email in Token mismatch{}", ex.getMessage());
                 response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
                 response.getWriter().write("User email in Token mismatch");
                 return;

--- a/src/main/java/com/syedhamed/ecommerce/security/JWTAuthFilter.java
+++ b/src/main/java/com/syedhamed/ecommerce/security/JWTAuthFilter.java
@@ -16,6 +16,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -107,7 +108,14 @@ public class JWTAuthFilter extends OncePerRequestFilter {
                 response.getWriter().write("Invalid token");
                 return;
 
-            } catch (Exception ex) {
+            } catch (UsernameNotFoundException ex){
+                log.error("User email in Token mismatch", ex.getMessage());
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                response.getWriter().write("User email in Token mismatch");
+                return;
+            }
+
+            catch (Exception ex) {
                 log.error("Unexpected error during JWT processing", ex);
                 response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
                 response.getWriter().write("Unexpected error while processing token");

--- a/src/main/java/com/syedhamed/ecommerce/service/implementation/AddressServiceImpl.java
+++ b/src/main/java/com/syedhamed/ecommerce/service/implementation/AddressServiceImpl.java
@@ -175,11 +175,13 @@ public class AddressServiceImpl implements AddressService {
     public Address updateAddressByAdmin(Long addressId, Address updatedAddressRequest) {
         Address existingAddress = addressRepository.findById(addressId)
                 .orElseThrow(() -> new ResourceNotFoundException("Address", "id", addressId));
-
+        updatedAddressRequest.setId(existingAddress.getId());
         // Update only the allowed fields
         modelMapper.map(updatedAddressRequest, existingAddress);
-
-        return addressRepository.save(existingAddress);
+        log.info("Saving updated address: [{}]", existingAddress);
+        Address address = addressRepository.save(existingAddress);
+        log.info("updated address: [{}]", address);
+        return address;
     }
 
 }

--- a/src/main/java/com/syedhamed/ecommerce/service/implementation/AddressServiceImpl.java
+++ b/src/main/java/com/syedhamed/ecommerce/service/implementation/AddressServiceImpl.java
@@ -125,13 +125,15 @@ public class AddressServiceImpl implements AddressService {
 
     @Override
     public Address getDefaultAddressFromCurrentUser() {
-        User currentUser = authUtil.getAuthenticatedUserFromCurrentContext();
+        Long userId = authUtil.getLoggedInUserId();
+        User user = userRepository.findByIdWithAddresses(userId)
+                .orElseThrow(() -> new ResourceNotFoundException("User", "id", userId));
 
         // Fetch the default address
-        return currentUser.getAddresses().stream()
+        return user.getAddresses().stream()
                 .filter(Address::isDefaultAddress)
                 .findFirst()
-                .orElseThrow(() -> new ResourceNotFoundException("Address", "default", "not found"));
+                .orElseThrow(() -> new ResourceNotFoundException("Address", "flag ", "default" ));
     }
 
     @Override

--- a/src/main/java/com/syedhamed/ecommerce/service/implementation/AddressServiceImpl.java
+++ b/src/main/java/com/syedhamed/ecommerce/service/implementation/AddressServiceImpl.java
@@ -37,6 +37,13 @@ public class AddressServiceImpl implements AddressService {
         }
         log.info("Is Default: [{}]", addressRequest.isDefaultAddress());
         User user = authUtil.getLoggedInUser();
+        if (addressRequest.isDefaultAddress()) {
+            user.getAddresses().forEach(address -> {
+                if (address.isDefaultAddress()){
+                    address.setDefaultAddress(false);
+                }
+            });
+        }
         Address address = new Address();
         modelMapper.map(addressRequest, address);
         address.setUser(user);

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -63,40 +63,39 @@ INSERT INTO products (product_name, description, quantity, price, discount, spec
 ('Action Figure Hero', 'Collectible superhero action figure', 100, 20.00, 3.00, 19.40, 'default.png', 5);
 
 
-INSERT INTO users (
-    id, email, password, first_name, last_name, phone, profile_image,
+INSERT INTO users (email, password, first_name, last_name, phone, profile_image,
     account_non_locked, enabled, email_verified,
     deleted, deleted_at, created_at, updated_at,
     deactivated, deactivated_at, seller_application_status
 ) VALUES
-(1, 'user1@example.com', '$2a$12$Qh.YDgSLUP5xT6i1ClpslOWiTySBDg6Fh3fMSi.py1OcoLDka4RHq', 'Alice', 'Wonder', '1234567890', 'user.png',
+('user1@example.com', '$2a$12$Qh.YDgSLUP5xT6i1ClpslOWiTySBDg6Fh3fMSi.py1OcoLDka4RHq', 'Alice', 'Wonder', '1234567890', 'user.png',
 true, true, true, false, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, false, NULL, 'NOT_REQUESTED'),
 
-(2, 'user2@example.com', '$2a$12$Qh.YDgSLUP5xT6i1ClpslOWiTySBDg6Fh3fMSi.py1OcoLDka4RHq', 'Bob', 'Builder', '1234567891', 'user.png',
+( 'user2@example.com', '$2a$12$Qh.YDgSLUP5xT6i1ClpslOWiTySBDg6Fh3fMSi.py1OcoLDka4RHq', 'Bob', 'Builder', '1234567891', 'user.png',
 true, true, true, true, DATEADD('DAY', -5, CURRENT_TIMESTAMP), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, false, NULL, 'NOT_REQUESTED'),
 
-(3, 'user3@example.com', '$2a$12$Qh.YDgSLUP5xT6i1ClpslOWiTySBDg6Fh3fMSi.py1OcoLDka4RHq', 'Charlie', 'Brown', '1234567892', 'user.png',
+('user3@example.com', '$2a$12$Qh.YDgSLUP5xT6i1ClpslOWiTySBDg6Fh3fMSi.py1OcoLDka4RHq', 'Charlie', 'Brown', '1234567892', 'user.png',
 true, false, true, false, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, true, DATEADD('DAY', -10, CURRENT_TIMESTAMP), 'NOT_REQUESTED'),
 
-(4, 'user4@example.com', '$2a$12$Qh.YDgSLUP5xT6i1ClpslOWiTySBDg6Fh3fMSi.py1OcoLDka4RHq', 'Daisy', 'Duck', '1234567893', 'user.png',
+( 'user4@example.com', '$2a$12$Qh.YDgSLUP5xT6i1ClpslOWiTySBDg6Fh3fMSi.py1OcoLDka4RHq', 'Daisy', 'Duck', '1234567893', 'user.png',
 false, true, true, false, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, false, NULL, 'NOT_REQUESTED'),
 
-(5, 'user5@example.com', '$2a$12$Qh.YDgSLUP5xT6i1ClpslOWiTySBDg6Fh3fMSi.py1OcoLDka4RHq', 'Evan', 'Peters', '1234567894', 'user.png',
+( 'user5@example.com', '$2a$12$Qh.YDgSLUP5xT6i1ClpslOWiTySBDg6Fh3fMSi.py1OcoLDka4RHq', 'Evan', 'Peters', '1234567894', 'user.png',
 true, true, true, true, DATEADD('DAY', -1, CURRENT_TIMESTAMP), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, false, NULL, 'NOT_REQUESTED'),
 
-(6, 'user6@example.com', '$2a$12$Qh.YDgSLUP5xT6i1ClpslOWiTySBDg6Fh3fMSi.py1OcoLDka4RHq', 'Fiona', 'Shrek', '1234567895', 'user.png',
+( 'user6@example.com', '$2a$12$Qh.YDgSLUP5xT6i1ClpslOWiTySBDg6Fh3fMSi.py1OcoLDka4RHq', 'Fiona', 'Shrek', '1234567895', 'user.png',
 true, false, true, true, DATEADD('DAY', -3, CURRENT_TIMESTAMP), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, true, DATEADD('DAY', -2, CURRENT_TIMESTAMP), 'NOT_REQUESTED'),
 
-(7, 'user7@example.com', '$2a$12$Qh.YDgSLUP5xT6i1ClpslOWiTySBDg6Fh3fMSi.py1OcoLDka4RHq', 'George', 'Clooney', '1234567896', 'user.png',
+( 'user7@example.com', '$2a$12$Qh.YDgSLUP5xT6i1ClpslOWiTySBDg6Fh3fMSi.py1OcoLDka4RHq', 'George', 'Clooney', '1234567896', 'user.png',
 true, true, true, false, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, false, NULL, 'NOT_REQUESTED'),
 
-(8, 'deleted8@example.com', '$2a$12$Qh.YDgSLUP5xT6i1ClpslOWiTySBDg6Fh3fMSi.py1OcoLDka4RHq', 'Hannah', 'Montana', '1234567897', 'user.png',
+( 'deleted8@example.com', '$2a$12$Qh.YDgSLUP5xT6i1ClpslOWiTySBDg6Fh3fMSi.py1OcoLDka4RHq', 'Hannah', 'Montana', '1234567897', 'user.png',
 false, false, true, true, DATEADD('DAY', -7, CURRENT_TIMESTAMP), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, false, NULL, 'NOT_REQUESTED'),
 
-(9, 'user9@example.com', '$2a$12$Qh.YDgSLUP5xT6i1ClpslOWiTySBDg6Fh3fMSi.py1OcoLDka4RHq', 'Ivy', 'League', '1234567898', 'user.png',
+( 'user9@example.com', '$2a$12$Qh.YDgSLUP5xT6i1ClpslOWiTySBDg6Fh3fMSi.py1OcoLDka4RHq', 'Ivy', 'League', '1234567898', 'user.png',
 true, false, true, false, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, true, DATEADD('DAY', -15, CURRENT_TIMESTAMP), 'NOT_REQUESTED'),
 
-(10, 'user10@example.com', '$2a$12$Qh.YDgSLUP5xT6i1ClpslOWiTySBDg6Fh3fMSi.py1OcoLDka4RHq', 'Jack', 'Sparrow', '1234567899', 'user.png',
+( 'user10@example.com', '$2a$12$Qh.YDgSLUP5xT6i1ClpslOWiTySBDg6Fh3fMSi.py1OcoLDka4RHq', 'Jack', 'Sparrow', '1234567899', 'user.png',
 true, true, true, false, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, false, NULL, 'NOT_REQUESTED');
 
 -- Permissions


### PR DESCRIPTION
## 🛠 Summary

This PR includes a series of critical bug fixes related to address management and authentication flow:

- 🧰 **Fixed multiple addresses being marked as default** in the database during address creation.
- 🔁 **Resolved LazyInitializationException** by:
  - Using `JOIN FETCH` for address fetches during update.
  - Forcing collection load in delete logic.
- 🚫 **Prevented JWT filter** from blocking unauthenticated user registration requests.
- 🚨 **Added error handling** in JWT filter for mismatched email tokens (`UsernameNotFoundException`).
- 🔐 **Removed manual setting of user IDs** to avoid `DataIntegrityViolationException` during registration.
- 🪪 **Changed ID generation strategy** from default to `IDENTITY` for better DB consistency.
- 💡 **Fixed model mapping bug** where incoming `null` ID was incorrectly linked to an existing address.

## 🧪 Tested
- Verified all affected endpoints:
  - User registration
  - Address create, update, delete
  - JWT token behavior for protected and public routes

## 📂 Related Files
- `AddressController.java`
- `AddressServiceImpl.java`
- `JwtAuthenticationFilter.java`
- `UserServiceImpl.java`
- `Address.java`

---