### PR TITLE
 Hotfix: Reassign default address on deletion

### DIFF
--- a/src/main/java/com/syedhamed/ecommerce/controllers/AddressController.java
+++ b/src/main/java/com/syedhamed/ecommerce/controllers/AddressController.java
@@ -64,11 +64,9 @@ public class AddressController {
 
     @DeleteMapping("/{addressId}")
     public ResponseEntity<APIResponse<String>> deleteAddress(@PathVariable Long addressId) {
-        if (isAdmin()) {
-            addressService.deleteAddressById(addressId);
-        } else {
+
             addressService.deleteAddressForCurrentUser(addressId);
-        }
+
         return ResponseEntity.ok(new APIResponse<>("Address deleted successfully", true));
     }
 

--- a/src/main/java/com/syedhamed/ecommerce/model/Address.java
+++ b/src/main/java/com/syedhamed/ecommerce/model/Address.java
@@ -6,6 +6,9 @@ import jakarta.persistence.*;
 import lombok.Data;
 import lombok.ToString;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
 
 @Entity
 @Data
@@ -23,6 +26,9 @@ public class Address {
     @Enumerated(EnumType.STRING)
     private AddressType addressType;
     private boolean defaultAddress;
+
+    private LocalDateTime createdAt;
+    private int usageCount;
 
 //    @JsonIgnore
     @JsonBackReference


### PR DESCRIPTION
## 🔥 Hotfix: Reassign default address after deletion

### 🧩 Problem
When a user deletes a default address, no fallback logic existed to reassign a new default. This caused issues in downstream logic relying on the presence of a default address.

### ✅ Fix
- Detects if the deleted address was marked as default.
- Reassigns a new default address from the user's address list.
  - Picks the address with the **highest usage count**.
  - Falls back to the **most recently added address** if all usage counts are zero.
- Avoids `LazyInitializationException` by loading address collection within a transactional context.

### 🧪 Testing
- Deleted a default address with:
  - other addresses present with varying usage counts
  - all addresses having zero usage count
- Verified that a new default address is automatically marked.

### 📄 Affected Areas
- `AddressServiceImpl.java`
- `User.getAddresses()`

---