### PR TITLE
FIX: Prevent duplicate CartItem entries and ensure accurate pricing using BigDecimal

### DIFF
--- a/src/main/java/com/syedhamed/ecommerce/controllers/ProductController.java
+++ b/src/main/java/com/syedhamed/ecommerce/controllers/ProductController.java
@@ -10,6 +10,7 @@ import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -29,7 +30,12 @@ public class ProductController {
     @PostMapping("/categories/{categoryId}/product")
     public ResponseEntity<ProductDTO> addProduct(@PathVariable Long categoryId,
                                                  @RequestBody @Valid  ProductDTO productDTO) {
-        ProductDTO response = productService.addProduct(categoryId, productDTO);
+        ProductDTO response = null;
+        try {
+            response = productService.addProduct(categoryId, productDTO);
+        } catch (AccessDeniedException e) {
+           return new ResponseEntity<>(null, HttpStatus.FORBIDDEN);
+        }
         return new ResponseEntity<>(response, HttpStatus.CREATED);
     }
 

--- a/src/main/java/com/syedhamed/ecommerce/model/Cart.java
+++ b/src/main/java/com/syedhamed/ecommerce/model/Cart.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -17,9 +18,9 @@ public class Cart {
     @GeneratedValue
     private Long id;
     // total special prices of all products as per quantity in the cart
-    private Double totalSpecialPrice;
+    private BigDecimal totalSpecialPrice;
     // total amount saved ( total price - total actual prices of all products as per quantity in the cart )
-    private Double totalSavedPrice;
+    private BigDecimal totalSavedPrice;
 
     @OneToMany(mappedBy = "cart", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
     private List<CartItem> cartItems = new ArrayList<>();

--- a/src/main/java/com/syedhamed/ecommerce/model/Product.java
+++ b/src/main/java/com/syedhamed/ecommerce/model/Product.java
@@ -8,6 +8,8 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 
+import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -23,9 +25,9 @@ public class Product { //owning side as per Category entity association
     private String description;
     private String productImage;
     private Integer quantity;
-    private Double price; //120$
-    private Double discount; //25%
-    private Double specialPrice; //90 [120-(25/100)*120]
+    private BigDecimal price; //120$
+    private BigDecimal discount; //25%
+    private BigDecimal specialPrice; //90 [120-(25/100)*120]
     @ManyToOne
     @JoinColumn(name = "category_id")
     @ToString.Exclude
@@ -42,6 +44,6 @@ public class Product { //owning side as per Category entity association
     @ToString.Exclude
     @JsonIgnore
     @OneToMany(mappedBy = "product", cascade = {CascadeType.PERSIST, CascadeType.MERGE})
-    private List<CartItem> cartItems;
+    private List<CartItem> cartItems= new ArrayList<>();
 
 }

--- a/src/main/java/com/syedhamed/ecommerce/service/implementation/ProductServiceImpl.java
+++ b/src/main/java/com/syedhamed/ecommerce/service/implementation/ProductServiceImpl.java
@@ -22,6 +22,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
 
@@ -60,9 +61,15 @@ public class ProductServiceImpl implements ProductService {
 
         product.setProductImage(DEFAULT_PRODUCT_IMAGE);
 
-        if (product.getDiscount() != null && product.getDiscount() > 0) {
-            double specialPrice = product.getPrice() -
-                    ((product.getDiscount() * 0.01) * product.getPrice());
+        if (product.getDiscount() != null && product.getDiscount().compareTo(BigDecimal.ZERO) > 0) {
+//            double specialPrice = product.getPrice() -
+//                    ((product.getDiscount() * 0.01) * product.getPrice());
+            BigDecimal specialPrice = product.getPrice()
+                            .subtract(
+                                    product.getDiscount()
+                                            .multiply(BigDecimal.valueOf(0.01))
+                                            .multiply(product.getPrice())
+                            );
             product.setSpecialPrice(specialPrice);
 
         }
@@ -117,16 +124,23 @@ public class ProductServiceImpl implements ProductService {
                 .orElseThrow(() -> new ResourceNotFoundException("Product", "id", productId));
         log.info("Product found by id: [{}]", productId);
         log.info("Current product's special price: [{}]", product.getSpecialPrice());
-        double updatedSpecialPrice = product.getSpecialPrice();
+        BigDecimal updatedSpecialPrice = product.getSpecialPrice();
         // Map the fields from ProductDTO to Product entity
         // Only non-null fields in productDTO will overwrite the corresponding fields in product
         modelMapper.map(productDTO, product);
         // Recalculate the special price if discount is available
         log.info("Recalculating special price...");
         log.info("Current special price: [{}]", updatedSpecialPrice);
-        if (product.getDiscount() != null && product.getDiscount() > 0) {
-            updatedSpecialPrice = product.getPrice() - ((product.getDiscount() * 0.01) * product.getPrice());
+        if (product.getDiscount() != null && product.getDiscount().compareTo(BigDecimal.ZERO) > 0) {
+//            updatedSpecialPrice = product.getPrice() - ((product.getDiscount() * 0.01) * product.getPrice());
+            updatedSpecialPrice = product.getPrice()
+                            .subtract(
+                                    product.getDiscount()
+                                            .multiply(BigDecimal.valueOf(0.01))
+                                            .multiply(product.getPrice())
+                            );
             product.setSpecialPrice(updatedSpecialPrice);
+
         }
         log.info("Updated special price: [{}]", product.getSpecialPrice());
 


### PR DESCRIPTION
## 🛠️ What This Fixes

- Fixed a logic error where duplicate `CartItem` entries were being added to the cart when updating product quantities.
- Ensures existing `CartItem` quantity is updated if the product is already in the cart, instead of adding a new item.
- Switched to using `BigDecimal` for price calculations to ensure accuracy and prevent rounding issues.

## 🔄 Changes Made

- ✅ Modified the cart update logic to check for existing `CartItem` by product.
- ✅ If a matching item is found, its quantity is updated instead of adding a new entry to the `List<CartItem>`.
- ✅ Replaced float/decimal arithmetic with `BigDecimal.multiply()` and `BigDecimal::add` for consistent pricing.

## 🐞 Problem Solved

Previously:
- Re-adding the same product to the cart resulted in **multiple `CartItem` entries**.
- This caused the cart total to be **doubled** or **miscalculated**.
- Price calculations were inaccurate due to the use of primitive decimal types.

Now:
- Only **one `CartItem` per product** exists in the cart.
- Total price reflects correct quantity × price for each unique product.
- Price math is handled via `BigDecimal` to ensure financial accuracy.

## ✅ Verification Steps

- Added same product twice → verified single cart item updated.
- Cart total now correctly reflects item quantities.
- Logs confirm correct calculation and cart state.

## 🧠 Note

This fix retains `List<CartItem>` as the backing collection and avoids switching to `Set` by manually ensuring item uniqueness.
